### PR TITLE
index: container app platform wording

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -4,9 +4,9 @@ title: OpenShift Origin - Open Source Container Application Platform
 
 <% content_for :header do %>
 <h1 class="animated fadeInDown delay">
-  The Open Source Application Container Platform
+  The Open Source Container Application Platform
 </h1>
-<p class="animated fadeInUp delay">Origin is the upstream community project that powers <a href="https://www.openshift.com" class="headerlink">OpenShift</a>. Built around a core of Docker container packaging and Kubernetes container cluster management, Origin is also augmented by application lifecycle management functionality and DevOps tooling. Origin provides a complete open source application container platform.</p>
+<p class="animated fadeInUp delay">Origin is the upstream community project that powers <a href="https://www.openshift.com" class="headerlink">OpenShift</a>. Built around a core of Docker container packaging and Kubernetes container cluster management, Origin is also augmented by application lifecycle management functionality and DevOps tooling. Origin provides a complete open source container application platform.</p>
 <% end %>
 
 <section class="timeline-responsive">
@@ -83,7 +83,7 @@ title: OpenShift Origin - Open Source Container Application Platform
         <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
           <h2>Run Origin in a Container</h2>
           <p>
-            Want to get started quickly and easily? Just <a href="https://docs.openshift.org/latest/getting_started/administrators.html#running-in-a-docker-container">run Origin in a Docker container</a> by itself. 
+            Want to get started quickly and easily? Just <a href="https://docs.openshift.org/latest/getting_started/administrators.html#running-in-a-docker-container">run Origin in a Docker container</a> by itself.
           </p>
         </div>
                 <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
@@ -114,7 +114,7 @@ title: OpenShift Origin - Open Source Container Application Platform
               <span>OpenShift Origin</span>?
             </h1>
             <p>
-              OpenShift Origin is the open source upstream project that powers OpenShift, Red Hat's application container platform.
+              OpenShift Origin is the open source upstream project that powers OpenShift, Red Hat's container application platform.
             </p>
           </div>
         </div>


### PR DESCRIPTION
- Fix wording of "application container platform" -> "container
  application platfrom"; closes #32

Signed-off-by: Jiri Fiala jfiala@redhat.com
