### PR TITLE
index: add cluster up instruction and doc link

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -1859,3 +1859,29 @@ aside .search .btn{
 	display: block;
 	font-size: 16px;
 }
+
+.code {
+    background: #122637;
+    color: #fff;
+    font-size: 20pt;
+}
+
+#get-started {
+    display: inline-block;
+    vertical-align: center;
+    background: #ee2d31;
+    color: #fff;
+    text-align: center;
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: normal;
+    padding: 15px 19px;
+    text-decoration: none;
+    transition: all .3s ease-in-out;
+}
+
+#get-started:hover {
+	opacity:0.8;
+}

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -95,6 +95,22 @@ title: OpenShift Origin - Open Source Container Application Platform
       <span>Origin</span> Release
     </h1>
   </div>
+  <div class="">
+    <div class="container wow fadeInUp">
+      <div class="row text-center">
+        <div class="col-xs-2 col-sm-2 col-md-2 col-lg-2"></div>
+        <div class="col-xs-8 col-sm-8 col-md-8 col-lg-8">
+          <pre class="code">$ oc cluster up    <a id="get-started" href="https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md" target="_blank">Get Started</a></pre>
+        </div>
+        <div class="col-xs-2 col-sm-2 col-md-2 col-lg-2"></div>
+      </div>
+    </div>
+  </div>
+  <div class="info_vertical animated">
+    <h3>
+      OR
+    </h3>
+  </div>
   <div class="padding_bottom">
     <div class="container wow fadeInUp">
       <div class="row text-center">


### PR DESCRIPTION
* Add the `cluster up` as prefered way of getting started with
  Openshift. This follows the content for the rebuild of the website
  (#46) which is not live yet. Closes #47
