### PR TITLE
minishift: update documentation to point to docs.openshift.org

### DIFF
--- a/source/minishift/index.html.erb
+++ b/source/minishift/index.html.erb
@@ -75,11 +75,10 @@ title: Minishift - Containerized OpenShift Cluster
         </p>
         <p>
           To download the latest <span>Minishift</span> release and view release notes, visit the
-          Minishift <a href="https://github.com/minishift/minishift/releases">releases page</a>.
+          <a href="https://github.com/minishift/minishift/releases">Minishift releases</a> page.
         </p>
         <p>
-          For detailed installation instructions, see the <a href="https://github.com/minishift/minishift/blob/master/README.md#installation">installation document</a>.
-          <!--TODO: When docs are published, changed README link to install page link-->
+          For detailed installation instructions, see the <a href="https://docs.openshift.org/latest/minishift/getting-started/installing.html">installation document</a>.
         </p>
       </div>
     </div>
@@ -100,14 +99,14 @@ title: Minishift - Containerized OpenShift Cluster
         <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
           <h2>Download</h2>
           <p>
-            Get the latest Minishift binaries and view release notes on the Minishift <a href="https://github.com/minishift/minishift/releases">releases page</a>.
+            Get the latest Minishift binaries and view release notes on the <a href="https://github.com/minishift/minishift/releases">Minishift releases</a> page.
             <!--TODO: Change to doc library link-->
           </p>
         </div>
         <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">
           <h2>Documentation</h2>
           <p>
-            Want to learn how to use, troubleshoot, and develop Minishift? Check out the available <a href="https://github.com/minishift/minishift/blob/master/README.md#documentation">documentation</a>.
+            Want to learn how to use, troubleshoot, and develop Minishift? Check out the available <a href="https://docs.openshift.org/latest/minishift/index.html">documentation</a>.
           </p>
         </div>
         <div class="col-xs-12 col-sm-4 col-md-4 col-lg-4">


### PR DESCRIPTION
Fixes issue https://github.com/minishift/minishift/issues/357

Now that we have published docs (YAY!!!!) this PR fixes the links to point to the hosted docs instead of the GitHub files. 

NOTE: Please review/merge ASAP as we are in the process of pushing the release and we would like to blast the URL of the landing page :D thanks for all the great help!