### PR TITLE
vm: redirect vm to minishif

### DIFF
--- a/source/.htaccess
+++ b/source/.htaccess
@@ -504,5 +504,6 @@ AddCharset utf-8 .atom .css .js .json .rss .vtt .xml
 
 # custom permanent redirects
 <IfModule mod_rewrite.c>
-  RewriteRule ^vm/instructions1_[2|3].*$ /vm/instructions1_4.html [R=301,L]
+  # RewriteRule ^vm/instructions1_[2|3].*$ /vm/instructions1_4.html [R=301,L]
+  RewriteRule ^vm/?(?!Vagrantfile$).*$ /minishift/ [R=301,L]
 </IfModule>


### PR DESCRIPTION
* adds a rewrite rule to redirect anything /vm/ to /minishift/,
  except the Vagrantfile refered in the "OpenShift for Developers" book

Requested-by: Jorge Morales
Signed-off-by: Jiri Fiala <jfiala@redhat.com>