### PR TITLE
timeline: add OpenShift 3.7 release

### DIFF
--- a/source/css/custom.scss
+++ b/source/css/custom.scss
@@ -482,7 +482,7 @@ ul.social {
 
 
 
-@media (max-width: 768px) {
+@media (max-width: 989px) {
     .bg_parallax {
         background-position-x: 10% !important;
     }
@@ -509,7 +509,7 @@ ul.social {
     }
 }
 
-@media (min-width: 769px) {
+@media (min-width: 990px) {
   .opacy_bg_02, .opacy_bg_05 {
       padding: 70px 0 130px;
   }

--- a/source/css/custom.scss
+++ b/source/css/custom.scss
@@ -420,6 +420,19 @@ ul.social {
             color: #000;
         }
     }
+
+    @media (max-width: $screen-sm-max) {
+      &:before {
+        bottom: 194px;
+      }
+      li {
+        display: none;
+        width: 33%;
+        &:nth-last-of-type(-n+3) {
+          display: inline-block;
+            }
+          }
+      }
 }
 .date {
     width: 100%;
@@ -469,11 +482,7 @@ ul.social {
 
 
 
-@media (min-width: $screen-md-min) {
-    .opacy_bg_02, .opacy_bg_05 {
-        padding: 70px 0 130px;
-    }
-
+@media (max-width: 768px) {
     .bg_parallax {
         background-position-x: 10% !important;
     }
@@ -498,6 +507,20 @@ ul.social {
     ul.social {
         float: right;
     }
+}
+
+@media (min-width: 769px) {
+  .opacy_bg_02, .opacy_bg_05 {
+      padding: 70px 0 130px;
+  }
+  
+  .timeline-responsive {
+      .opacy_bg_03 {
+          #timeline .date {
+              top: -85px;
+          }
+      }
+  }
 }
 
 @media (max-width: 991px) {
@@ -531,15 +554,6 @@ ul.social {
         p {
             font-size: 21px;
             line-height: normal;
-        }
-    }
-
-    .timeline-responsive {
-        .opacy_bg_03 {
-            min-width: 600px;
-            #timeline .date {
-                top: -90px;
-            }
         }
     }
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -27,34 +27,25 @@ title: OpenShift Origin - Open Source Container Application Platform
           <li class="entry">
             <label>
               <span>
-                Work begins on Docker and Kubernetes-based core platform (Origin 1.0 and OpenShift 3)
+                Work begins on Docker and Kubernetes-based core platform (OpenShift&nbsp;3)
               </span>
             </label>
-            <span class="date">June 2013</span>
+            <span class="date">Jun 2013</span>
             <span class="circle"></span>
           </li>
           <li class="entry">
             <label>
               <span>
-                OpenShift Origin 1.0 Release (OpenShift 3)
+                OpenShift Origin&nbsp;1.0 Release (OpenShift&nbsp;3)
               </span>
             </label>
-            <span class="date">June 2015</span>
+            <span class="date">Jun 2015</span>
             <span class="circle"></span>
           </li>
           <li class="entry">
             <label>
               <span>
-                OpenShift Origin 1.1 Release (OpenShift 3.1)
-              </span>
-            </label>
-            <span class="date">Nov 2015</span>
-            <span class="circle"></span>
-          </li>
-          <li class="entry">
-            <label>
-              <span>
-                OpenShift Origin 1.2 Release (OpenShift 3.2)
+                OpenShift Origin&nbsp;1.2 Release (OpenShift&nbsp;3.2)
               </span>
             </label>
             <span class="date">May 2016</span>
@@ -63,7 +54,7 @@ title: OpenShift Origin - Open Source Container Application Platform
           <li class="entry">
             <label>
               <span>
-                OpenShift Origin 1.3 Release (OpenShift 3.3)
+                OpenShift Origin&nbsp;1.3 Release (OpenShift&nbsp;3.3)
               </span>
             </label>
             <span class="date">Sep 2016</span>
@@ -72,7 +63,7 @@ title: OpenShift Origin - Open Source Container Application Platform
           <li class="entry">
             <label>
               <span>
-                <a href="https://blog.openshift.com/announcing-red-hat-openshift-container-platform-3-4-ga/">OpenShift Origin 1.4 Release (OpenShift 3.4)</a>
+                <a href="https://blog.openshift.com/announcing-red-hat-openshift-container-platform-3-4-ga/">OpenShift Origin&nbsp;1.4 Release (OpenShift&nbsp;3.4)</a>
               </span>
             </label>
             <span class="date">Jan 2017</span>
@@ -81,19 +72,28 @@ title: OpenShift Origin - Open Source Container Application Platform
           <li class="entry">
             <label>
               <span>
-                <a href="https://blog.openshift.com/announcing-the-openshift-container-platform-3-5-ga/">OpenShift Origin 1.5 Release (OpenShift 3.5)</a>
+                <a href="https://blog.openshift.com/announcing-the-openshift-container-platform-3-5-ga/">OpenShift Origin&nbsp;1.5 Release (OpenShift&nbsp;3.5)</a>
               </span>
             </label>
-            <span class="date">April 2017</span>
+            <span class="date">Apr 2017</span>
             <span class="circle"></span>
           </li>
           <li class="entry">
             <label>
               <span>
-                <a href="https://blog.openshift.com/announcing-the-openshift-container-platform-3-6-ga/">OpenShift Origin 3.6 Release (OpenShift 3.6)</a>
+                <a href="https://blog.openshift.com/announcing-the-openshift-container-platform-3-6-ga/">OpenShift Origin&nbsp;3.6 Release</a>
               </span>
             </label>
-            <span class="date">July 2017</span>
+            <span class="date">Jul 2017</span>
+            <span class="circle"></span>
+          </li>
+          <li class="entry">
+            <label>
+              <span>
+                <a href="https://blog.openshift.com/announcing-the-openshift-container-platform-3-7-ga/">OpenShift Origin&nbsp;3.7 Release</a>
+              </span>
+            </label>
+            <span class="date">Nov 2017</span>
             <span class="circle circle-big"></span>
           </li>
         </ul>


### PR DESCRIPTION
* adds OpenShift 3.7 release on the timeline with a link to OCP 3.7 GA
  blog post; closes #91
* displays only lat 3 list items on smaller viewports and adjust
  element positioning slighly

Requested-by: Oleg Bulatov
Signed-off-by: Jiri Fiala <jfiala@redhat.com>