### PR TITLE
timeline: add OpenShift 3.9 release

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -45,15 +45,6 @@ title: OpenShift Origin - Open Source Container Application Platform
           <li class="entry">
             <label>
               <span>
-                OpenShift Origin&nbsp;1.2 Release (OpenShift&nbsp;3.2)
-              </span>
-            </label>
-            <span class="date">May 2016</span>
-            <span class="circle"></span>
-          </li>
-          <li class="entry">
-            <label>
-              <span>
                 OpenShift Origin&nbsp;1.3 Release (OpenShift&nbsp;3.3)
               </span>
             </label>
@@ -94,6 +85,15 @@ title: OpenShift Origin - Open Source Container Application Platform
               </span>
             </label>
             <span class="date">Nov 2017</span>
+            <span class="circle"></span>
+          </li>
+          <li class="entry">
+            <label>
+              <span>
+                <a href="https://blog.openshift.com/announcing-the-openshift-container-platform-3-9-ga/">OpenShift Origin&nbsp;3.9 Release</a>
+              </span>
+            </label>
+            <span class="date">March 2018</span>
             <span class="circle circle-big"></span>
           </li>
         </ul>


### PR DESCRIPTION
* adds OpenShift 3.9 release on the timeline with a link to OCP 3.9 GA
  blog post

Signed-off-by: Jiri Fiala <jfiala@redhat.com>