### PR TITLE
remove information duplicated in Minishift documentation

### DIFF
--- a/source/minishift/index.html.erb
+++ b/source/minishift/index.html.erb
@@ -41,7 +41,7 @@ title: Minishift - Containerized OpenShift Cluster
           develop with it, day-to-day, on your local machine.
         </p>
         <p>
-          You can run Minishift on Windows, macOS, and GNU/Linux operating systems. Minishift
+          You can run Minishift on the Windows, macOS, and GNU/Linux operating systems. Minishift
           uses <a href="https://github.com/docker/machine/tree/master/libmachine">libmachine</a>
           for provisioning virtual machines, and <a href="https://github.com/openshift/origin">OpenShift Origin</a>
           for running the cluster.
@@ -57,27 +57,13 @@ title: Minishift - Containerized OpenShift Cluster
     </div>
     <div class="row wow info_vertical animated fadeInUp">
       <h1>Get Started</h1>
-        <div class="col-md-12 text-left">
-          <p>
-          Minishift requires a hypervisor to run the virtual machine containing OpenShift. Depending on your
-          host operating system, you have the choice of the following hypervisors:
-          </p>
-        <p>
-          <ul>
-          <li>macOS: <a href="https://github.com/mist64/xhyve">xhyve</a> (default), <a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox</a>
-          </li>
-          <li>GNU/Linux: <a href="https://docs.openshift.org/latest/minishift/getting-started/setting-up-driver-plugin.html#kvm-driver-install">KVM</a> (default), <a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox</a>
-          </li>
-          <li>Windows: <a href="https://technet.microsoft.com/en-us/library/mt169373.aspx">Hyper-V</a> (default), <a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox</a>
-          </li>
-        </ul>
-        </p>
+      <div class="col-md-12 text-left">
         <p>
           To download the latest <span>Minishift</span> release and view release notes, visit the
           <a href="https://github.com/minishift/minishift/releases">Minishift releases</a> page.
         </p>
         <p>
-          For detailed installation instructions, see the <a href="https://docs.openshift.org/latest/minishift/getting-started/installing.html">installation document</a>.
+          For detailed installation instructions, see the <a href="https://docs.openshift.org/latest/minishift/getting-started/preparing-to-install.html">installation document</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
This also helps guide the user to the documentation more appropriately.